### PR TITLE
Add gitignore with some useful stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.sass-cache
+.DS_Store
+Thumbs.db
+node_modules
+npm-debug.log


### PR DESCRIPTION
IMO it's a good idea not to check in `.sass-cache`, as you'll generate some larger than necessary diffs (see http://stackoverflow.com/questions/20105123/should-i-include-sass-cache-with-the-repo-when-versioning-a-web-project). Also add some `node` and OS related stuff that might be useful for you or other contributors to not check in.
